### PR TITLE
feat: side effects and event handlers

### DIFF
--- a/Bloc.NET.Tests/test/src/AsyncBlocTest.cs
+++ b/Bloc.NET.Tests/test/src/AsyncBlocTest.cs
@@ -119,27 +119,27 @@ public class AsyncBlocTest {
   }
 
   [Fact]
-  public async Task UpdatesActionObservers() {
-    using var bloc = new TestBlocWithActions();
+  public async Task UpdatesEffectObservers() {
+    using var bloc = new TestBlocWithEffects();
     var enumerator = bloc.States.ToAsyncEnumerable().GetAsyncEnumerator();
 
     var streamWasCalled = false;
-    var expectedAction = 1;
-    using var subscription = bloc.Actions.Subscribe(
-      onNext: (action) => {
-        action.ShouldBe(expectedAction);
+    var expectedEffect = 1;
+    using var subscription = bloc.Effects.Subscribe(
+      onNext: (effect) => {
+        effect.ShouldBe(expectedEffect);
         streamWasCalled = true;
       }
     );
 
     var handlerWasCalled = false;
-    var actionHandler = new EventHandler<int>((b, action) => {
+    var effectHandler = new EventHandler<int>((b, effect) => {
       b.ShouldBe(bloc);
-      action.ShouldBe(expectedAction);
+      effect.ShouldBe(expectedEffect);
       handlerWasCalled = true;
     });
 
-    bloc.OnAction += actionHandler;
+    bloc.OnEffect += effectHandler;
 
     bloc.Add(new ITestEvent.Increment());
 
@@ -147,7 +147,7 @@ public class AsyncBlocTest {
     streamWasCalled.ShouldBeTrue();
     handlerWasCalled.ShouldBeTrue();
 
-    bloc.OnAction -= actionHandler;
+    bloc.OnEffect -= effectHandler;
   }
 
   [Fact]
@@ -285,7 +285,7 @@ public class AsyncBlocTest {
   }
 
   [Fact]
-  public void BlocClassicCannotTriggerAction() {
+  public void BlocClassicCannotTriggerEffect() {
     using var bloc = new TestBlocClassicTrigger();
     Should.Throw<InvalidOperationException>(() => bloc.Trigger());
   }
@@ -370,10 +370,10 @@ public class AsyncBlocTest {
     }
   }
 
-  public class TestBlocWithActions : AsyncBloc<ITestEvent, int, int> {
+  public class TestBlocWithEffects : AsyncBloc<ITestEvent, int, int> {
     public const int INITIAL_STATE = 0;
 
-    public TestBlocWithActions() : base(INITIAL_STATE) {
+    public TestBlocWithEffects() : base(INITIAL_STATE) {
       On<ITestEvent.Increment>(Increment);
       On<ITestEvent.Decrement>(Decrement);
     }
@@ -398,7 +398,7 @@ public class AsyncBlocTest {
 
     public TestBlocClassicTrigger() : base(INITIAL_STATE) { }
 
-    public void Trigger() => Trigger("action");
+    public void Trigger() => Trigger("effect");
   }
 
   public class TestBlocDuplicateRegistrations : Bloc<string, int> {

--- a/Bloc.NET.Tests/test/src/SyncBlocTest.cs
+++ b/Bloc.NET.Tests/test/src/SyncBlocTest.cs
@@ -2,8 +2,6 @@ namespace Bloc.NET.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
 
@@ -14,135 +12,6 @@ public class SyncBlocTest {
   public void Initializes() {
     using var bloc = new TestBloc();
     bloc.State.ShouldBe(TestBloc.INITIAL_STATE);
-  }
-
-  [Fact]
-  public void Finalizes() {
-    WasBlocClosed = false;
-    // Weak reference has to be created and cleared from a static function
-    // or else the GC won't ever collect it :P
-    var weakBloc = CreateWeakReference();
-    Utils.ClearWeakReference(weakBloc);
-
-    // Our weak reference to our bloc will have triggered its finalizers now.
-    WasBlocClosed.ShouldBeTrue();
-  }
-
-  [Fact]
-  public void DoesNothingOnRepeatedDispose() {
-    var bloc = new TestBloc();
-    bloc.Dispose();
-    Should.NotThrow(() => bloc.Dispose());
-  }
-
-  [Fact]
-  public void Enumerates() {
-    using var bloc = new TestBloc();
-    var enumerator = bloc.States.GetEnumerator();
-
-    enumerator.MoveNext();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE);
-
-    bloc.Add("+");
-    enumerator.MoveNext();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE + 1);
-    bloc.Add("+");
-    enumerator.MoveNext();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE + 2);
-
-    bloc.Add("+");
-    enumerator.MoveNext();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE + 3);
-  }
-
-  [Fact]
-  public async Task EnumeratesAsync() {
-    using var bloc = new TestBloc();
-    var enumerator = bloc.Stream.GetAsyncEnumerator();
-
-    await enumerator.MoveNextAsync();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE);
-
-    bloc.Add("+");
-    await enumerator.MoveNextAsync();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE + 1);
-    bloc.Add("+");
-    await enumerator.MoveNextAsync();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE + 2);
-    bloc.Add("+");
-    await enumerator.MoveNextAsync();
-    enumerator.Current.ShouldBe(TestBloc.INITIAL_STATE + 3);
-  }
-
-  [Fact]
-  public void OnNextStateIsInvoked() {
-    using var bloc = new TestBloc();
-    var onNextStateCalled = 0;
-    void onNextState(object? bloc, int s) => onNextStateCalled++;
-    bloc.OnNextState += onNextState;
-
-    bloc.Add("+");
-    onNextStateCalled.ShouldBe(1);
-
-    bloc.OnNextState -= onNextState;
-    bloc.Add("+");
-    onNextStateCalled.ShouldBe(1);
-  }
-
-  [Fact]
-  public void OnStateIsInvoked() {
-    using var bloc = new TestBloc();
-    var onStateCalled = 0;
-    void onState(object? bloc, int s) => onStateCalled++;
-    bloc.OnState += onState;
-
-    bloc.Add("+");
-    onStateCalled.ShouldBe(2);
-
-    bloc.OnState -= onState;
-    bloc.Add("+");
-    onStateCalled.ShouldBe(2);
-  }
-
-  [Fact]
-  public void OnNextErrorIsInvoked() {
-    using var bloc = new TestErrorBloc();
-    var onNextErrorCalled = 0;
-    void onNextError(object? bloc, Exception e) => onNextErrorCalled++;
-    bloc.OnNextError += onNextError;
-
-    Should.Throw<Exception>(() => bloc.Add("+"));
-    onNextErrorCalled.ShouldBe(1);
-  }
-
-  [Fact]
-  public void OnNextErrorIsNotInvokedIfRemoved() {
-    using var bloc = new TestErrorBloc();
-    var onNextErrorCalled = 0;
-    void onNextError(object? bloc, Exception e) => onNextErrorCalled++;
-    bloc.OnNextError += onNextError;
-    bloc.OnNextError -= onNextError;
-
-    Should.Throw<Exception>(() => bloc.Add("+"));
-    onNextErrorCalled.ShouldBe(0);
-  }
-
-  [Fact]
-  public void EventsAreMappedToState() {
-    using var bloc = new TestBloc();
-    bloc.Add("+");
-    bloc.State.ShouldBe(TestBloc.INITIAL_STATE + 1);
-    bloc.Add("-");
-    bloc.State.ShouldBe(TestBloc.INITIAL_STATE);
-  }
-
-  [Fact]
-  public void ListenRespondsToEvents() {
-    using var bloc = new TestBloc();
-    var state = TestBloc.INITIAL_STATE;
-    using var subscription = bloc.Listen(s => state = s);
-    bloc.Add("+");
-    state.ShouldBe(TestBloc.INITIAL_STATE + 1);
   }
 
   [Fact]
@@ -161,78 +30,23 @@ public class SyncBlocTest {
   }
 
   [Fact]
-  public void ListenHandlesErrorWithDefaultHandler() {
-    using var bloc = new TestErrorBloc();
-    var state = TestErrorBloc.INITIAL_STATE;
-    using var subscription = bloc.Listen(s => state = s);
-
-    Should.Throw<Exception>(() => bloc.Add("+"));
-
-    // Events that cause errors to be thrown in OnEvent should not affect
-    // state.
-    bloc.State.ShouldBe(TestErrorBloc.INITIAL_STATE);
+  public void SyncBlocClassicCannotTriggerAction() {
+    using var bloc = new TestBlocClassicTrigger();
+    Should.Throw<InvalidOperationException>(() => bloc.Trigger());
   }
 
-  [Fact]
-  public void AddsError() {
-    using var bloc = new TestError2Bloc();
+  public class TestBlocClassicTrigger : SyncBlocClassic<string, int> {
+    public const int INITIAL_STATE = 0;
 
-    var states = new List<int>();
-    using var subscription = bloc.Listen(s => states.Add(s));
+    public TestBlocClassicTrigger() : base(INITIAL_STATE) { }
 
-    var errorEventCalled = false;
-    bloc.OnNextError += (_, e) => {
-      e.ShouldBeOfType<InvalidOperationException>();
-      errorEventCalled = true;
-    };
+    public override IEnumerable<int> MapEventToState(string @event) =>
+      throw new NotImplementedException();
 
-    bloc.Add("event");
-
-    states.ShouldBe(new[] { TestError2Bloc.INITIAL_STATE, 1, 2, 3 });
-    errorEventCalled.ShouldBeTrue();
+    public void Trigger() => Trigger("action");
   }
 
-  [Fact]
-  public void ListenHandlesCompletion() {
-    var bloc = new TestBloc();
-    var onCompletedCalled = false;
-    using var subscription = bloc.Listen(_ => { }, onCompleted: () => onCompletedCalled = true);
-    bloc.Add("+");
-    bloc.Dispose();
-    onCompletedCalled.ShouldBeTrue();
-  }
-
-  [Fact]
-  public void ListenHandlesCompletionWithDefaultHandler() {
-    var bloc = new TestBloc();
-    using var subscription = bloc.Listen(_ => { });
-    bloc.Add("+");
-    bloc.Dispose();
-  }
-
-  [Fact]
-  public void ListenHandlesCancellation() {
-    using var bloc = new TestBloc();
-    var onCanceledCalled = false;
-    var cancellation = new CancellationTokenSource();
-    using var subscription = bloc.Listen(_ => { });
-    cancellation.Token.Register(() => onCanceledCalled = true);
-    bloc.Add("+");
-    cancellation.Cancel();
-    onCanceledCalled.ShouldBeTrue();
-  }
-
-  public static WeakReference CreateWeakReference() => new(new TestBloc());
-
-  public static class Utils {
-    public static void ClearWeakReference(WeakReference weakReference) {
-      weakReference.Target = null;
-      GC.Collect();
-      GC.WaitForPendingFinalizers();
-    }
-  }
-
-  public class TestErrorBloc : SyncBloc<string, int> {
+  public class TestErrorBloc : SyncBlocClassic<string, int> {
     public const int INITIAL_STATE = 0;
 
     public TestErrorBloc() : base(INITIAL_STATE) { }
@@ -241,20 +55,7 @@ public class SyncBlocTest {
       => throw new InvalidOperationException();
   }
 
-  public class TestError2Bloc : SyncBloc<string, int> {
-    public const int INITIAL_STATE = 0;
-
-    public TestError2Bloc() : base(INITIAL_STATE) { }
-
-    public override IEnumerable<int> MapEventToState(string @event) {
-      yield return 1;
-      AddError(new InvalidOperationException());
-      yield return 2;
-      yield return 3;
-    }
-  }
-
-  public class TestBloc : SyncBloc<string, int> {
+  public class TestBloc : SyncBlocClassic<string, int> {
     public const int INITIAL_STATE = 0;
 
     public TestBloc() : base(INITIAL_STATE) { }
@@ -271,16 +72,6 @@ public class SyncBlocTest {
           yield return State;
           break;
       }
-    }
-
-    ~TestBloc() {
-      WasBlocClosed = true;
-    }
-  }
-
-  public class MyObject {
-    ~MyObject() {
-      WasBlocClosed = true;
     }
   }
 }

--- a/Bloc.NET.Tests/test/src/SyncBlocTest.cs
+++ b/Bloc.NET.Tests/test/src/SyncBlocTest.cs
@@ -51,7 +51,7 @@ public class SyncBlocTest {
   }
 
   [Fact]
-  public void SyncBlocClassicCannotTriggerAction() {
+  public void SyncBlocClassicCannotTriggerEffect() {
     using var bloc = new TestBlocClassicTrigger();
     Should.Throw<InvalidOperationException>(() => bloc.Trigger());
   }
@@ -67,7 +67,7 @@ public class SyncBlocTest {
 
     public TestBlocClassicTrigger() : base(INITIAL_STATE) { }
 
-    public void Trigger() => Trigger("action");
+    public void Trigger() => Trigger("effect");
   }
 
   public class TestErrorBloc : SyncBlocClassic<ITestEvent, int> {

--- a/Bloc.NET.Tests/test/src/utilities/BlocGlueFakeBloc.cs
+++ b/Bloc.NET.Tests/test/src/utilities/BlocGlueFakeBloc.cs
@@ -14,7 +14,7 @@ public partial class BlocGlueTests {
     public record StateB(string Value1, string Value2) : FakeBlocState;
   }
 
-  public class FakeBloc : SyncBloc<IFakeBlocEvent, FakeBlocState> {
+  public class FakeBloc : SyncBlocClassic<IFakeBlocEvent, FakeBlocState> {
     public FakeBloc() : base(new FakeBlocState.StateA(1, 2)) { }
 
     public override IEnumerable<FakeBlocState> MapEventToState(

--- a/Bloc.NET.Tests/test/src/utilities/BlocGlueFakeBloc.cs
+++ b/Bloc.NET.Tests/test/src/utilities/BlocGlueFakeBloc.cs
@@ -15,17 +15,21 @@ public partial class BlocGlueTests {
   }
 
   public class FakeBloc : SyncBlocClassic<IFakeBlocEvent, FakeBlocState> {
-    public FakeBloc() : base(new FakeBlocState.StateA(1, 2)) { }
+    public FakeBloc() : base(new FakeBlocState.StateA(1, 2)) {
+      On<IFakeBlocEvent.EventOne>(One);
+      On<IFakeBlocEvent.EventTwo>(Two);
+    }
 
-    public override IEnumerable<FakeBlocState> MapEventToState(
-      IFakeBlocEvent @event
+    private IEnumerable<FakeBlocState> One(
+      IFakeBlocEvent.EventOne @event
     ) {
-      if (@event is IFakeBlocEvent.EventOne one) {
-        yield return new FakeBlocState.StateA(one.Value1, one.Value2);
-      }
-      else if (@event is IFakeBlocEvent.EventTwo two) {
-        yield return new FakeBlocState.StateB(two.Value1, two.Value2);
-      }
+      yield return new FakeBlocState.StateA(@event.Value1, @event.Value2);
+    }
+
+    private IEnumerable<FakeBlocState> Two(
+      IFakeBlocEvent.EventTwo @event
+    ) {
+      yield return new FakeBlocState.StateB(@event.Value1, @event.Value2);
     }
   }
 }

--- a/Bloc.NET.Tests/test/src/utilities/BlocGlueFakeBloc.cs
+++ b/Bloc.NET.Tests/test/src/utilities/BlocGlueFakeBloc.cs
@@ -14,7 +14,13 @@ public partial class BlocGlueTests {
     public record StateB(string Value1, string Value2) : FakeBlocState;
   }
 
-  public class FakeBloc : SyncBlocClassic<IFakeBlocEvent, FakeBlocState> {
+  public interface IFakeBlocEffect {
+    public record struct EffectOne(int Value) : IFakeBlocEffect;
+    public record struct EffectTwo(string Value) : IFakeBlocEffect;
+  }
+
+  public class FakeBloc
+    : SyncBloc<IFakeBlocEvent, FakeBlocState, IFakeBlocEffect> {
     public FakeBloc() : base(new FakeBlocState.StateA(1, 2)) {
       On<IFakeBlocEvent.EventOne>(One);
       On<IFakeBlocEvent.EventTwo>(Two);
@@ -23,12 +29,14 @@ public partial class BlocGlueTests {
     private IEnumerable<FakeBlocState> One(
       IFakeBlocEvent.EventOne @event
     ) {
+      Trigger(new IFakeBlocEffect.EffectOne(1));
       yield return new FakeBlocState.StateA(@event.Value1, @event.Value2);
     }
 
     private IEnumerable<FakeBlocState> Two(
       IFakeBlocEvent.EventTwo @event
     ) {
+      Trigger(new IFakeBlocEffect.EffectTwo("2"));
       yield return new FakeBlocState.StateB(@event.Value1, @event.Value2);
     }
   }

--- a/Bloc.NET.Tests/test/src/utilities/BlocGlueTest.cs
+++ b/Bloc.NET.Tests/test/src/utilities/BlocGlueTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 public partial class BlocGlueTests {
   [Fact]
-  public void CallsCorrectActionsOnEventUpdates() {
+  public void UpdatesCorrectly() {
     using var bloc = new FakeBloc();
     using var glue = bloc.Glue();
 
@@ -54,5 +54,31 @@ public partial class BlocGlueTests {
 
     callA1.ShouldBe(3);
     callA2.ShouldBe(2);
+  }
+
+  [Fact]
+  public void HandlesEffects() {
+    using var bloc = new FakeBloc();
+    using var glue = bloc.Glue();
+
+    var callEffect1 = 0;
+    var callEffect2 = 0;
+
+    glue.Handle<IFakeBlocEffect.EffectOne>(
+      (effect) => { callEffect1++; effect.Value.ShouldBe(1); })
+      .Handle<IFakeBlocEffect.EffectTwo>(
+      (effect) => { callEffect2++; effect.Value.ShouldBe("2"); });
+
+    // Effects should get handled each time, regardless of if they are
+    // identical to the previous one.
+
+    bloc.Add(new IFakeBlocEvent.EventOne(1, 2));
+    bloc.Add(new IFakeBlocEvent.EventOne(1, 2));
+
+    bloc.Add(new IFakeBlocEvent.EventTwo("a", "b"));
+    bloc.Add(new IFakeBlocEvent.EventTwo("a", "b"));
+
+    callEffect1.ShouldBe(2);
+    callEffect2.ShouldBe(2);
   }
 }

--- a/Bloc.NET/src/AsyncBloc.cs
+++ b/Bloc.NET/src/AsyncBloc.cs
@@ -16,8 +16,11 @@ using System.Runtime.CompilerServices;
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
 /// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public abstract class AsyncBloc<TEvent, TState, TAction>
-  : GenericBloc<TEvent, TState, TAction> where TState : IEquatable<TState> {
+public abstract class AsyncBloc<TEvent, TState, TAction> :
+  GenericBloc<TEvent, TState, TAction>
+  where TEvent : notnull
+  where TState : IEquatable<TState>
+  where TAction : notnull {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>
@@ -25,16 +28,17 @@ public abstract class AsyncBloc<TEvent, TState, TAction>
   public AsyncBloc(TState initialState) : base(initialState) { }
 
   /// <summary>
-  /// Whenever a bloc processes an event, this method is called with the event
-  /// and expected to return the next state of the bloc. This method is used
-  /// to map an event to a new state based on the bloc's current state.
+  /// Registers an event handler for a specific event type. The event handler
+  /// is a function that receives an event of a specific type and emits one or
+  /// more states in response to the event.
   /// </summary>
-  /// <param name="event">The event to process.</param>
-  public abstract IAsyncEnumerable<TState> MapEventToState(TEvent @event);
-
-  /// <inheritdoc/>
-  protected sealed override IObservable<TState> ConvertEvent(TEvent @event) =>
-    MapEventToState(@event).ToObservable();
+  /// <param name="handler">Event handler.</param>
+  /// <typeparam name="TEventType">Type of the event.</typeparam>
+  protected void On<TEventType>(
+    Func<TEventType, IAsyncEnumerable<TState>> handler
+  ) where TEventType : TEvent => On<TEventType>(
+    (@event) => handler(@event).ToObservable()
+  );
 
   /// <inheritdoc/>
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -60,8 +64,9 @@ public abstract class AsyncBloc<TEvent, TState, TAction>
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-public abstract class Bloc<TEvent, TState>
-  : AsyncBloc<TEvent, TState, object> where TState : IEquatable<TState> {
+public abstract class Bloc<TEvent, TState> : AsyncBloc<TEvent, TState, object>
+  where TEvent : notnull
+  where TState : IEquatable<TState> {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>

--- a/Bloc.NET/src/AsyncBloc.cs
+++ b/Bloc.NET/src/AsyncBloc.cs
@@ -15,8 +15,9 @@ using System.Runtime.CompilerServices;
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-public abstract class AsyncBloc<TEvent, TState> : GenericBloc<TEvent, TState>
-  where TState : IEquatable<TState> {
+/// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
+public abstract class AsyncBloc<TEvent, TState, TAction>
+  : GenericBloc<TEvent, TState, TAction> where TState : IEquatable<TState> {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>
@@ -40,4 +41,36 @@ public abstract class AsyncBloc<TEvent, TState> : GenericBloc<TEvent, TState>
   protected sealed override bool ShouldThrow(Exception e) => false;
   // Async blocs shouldn't throw exceptions when adding an event. Adding the
   // error to the error stream is sufficient.
+}
+
+/// <summary>
+/// <para>
+/// A bloc is a component that processes events and maintains a state. In
+/// game development, blocs can be used in place of traditional state machines,
+/// HSM's, or state charts. While blocs are not as rigorously defined as state
+/// machines, they are easy to test and offer increased flexibility (and often
+/// require less code).
+/// </para>
+/// <para>
+/// Unlike <see cref="AsyncBloc{TEvent, TState, TAction}"/>, this bloc cannot
+/// trigger actions. The lack of actions replicates the API surface of the
+/// original bloc library for Flutter and is useful when you do not need blocs
+/// to trigger one-shot actions unrelated to state.
+/// </para>
+/// </summary>
+/// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
+/// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
+public abstract class Bloc<TEvent, TState>
+  : AsyncBloc<TEvent, TState, object> where TState : IEquatable<TState> {
+  /// <summary>
+  /// Creates a new bloc with the given initial state.
+  /// </summary>
+  /// <param name="initialState">Initial state of the bloc.</param>
+  public Bloc(TState initialState) : base(initialState) { }
+
+  /// <inheritdoc/>
+  protected override void Trigger(object action) =>
+    throw new InvalidOperationException(
+      "This bloc does not support actions. Use an AsyncBloc to trigger actions."
+    );
 }

--- a/Bloc.NET/src/AsyncBloc.cs
+++ b/Bloc.NET/src/AsyncBloc.cs
@@ -15,12 +15,12 @@ using System.Runtime.CompilerServices;
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-/// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public abstract class AsyncBloc<TEvent, TState, TAction> :
-  GenericBloc<TEvent, TState, TAction>
+/// <typeparam name="TEffect">Type of effects the bloc can trigger.</typeparam>
+public abstract class AsyncBloc<TEvent, TState, TEffect> :
+  GenericBloc<TEvent, TState, TEffect>
   where TEvent : notnull
   where TState : IEquatable<TState>
-  where TAction : notnull {
+  where TEffect : notnull {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>
@@ -56,10 +56,10 @@ public abstract class AsyncBloc<TEvent, TState, TAction> :
 /// require less code).
 /// </para>
 /// <para>
-/// Unlike <see cref="AsyncBloc{TEvent, TState, TAction}"/>, this bloc cannot
-/// trigger actions. The lack of actions replicates the API surface of the
+/// Unlike <see cref="AsyncBloc{TEvent, TState, TEffect}"/>, this bloc cannot
+/// trigger effects. The lack of effects replicates the API surface of the
 /// original bloc library for Flutter and is useful when you do not need blocs
-/// to trigger one-shot actions unrelated to state.
+/// to trigger one-shot effects unrelated to state.
 /// </para>
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
@@ -76,6 +76,6 @@ public abstract class Bloc<TEvent, TState> : AsyncBloc<TEvent, TState, object>
   /// <inheritdoc/>
   protected override void Trigger(object action) =>
     throw new InvalidOperationException(
-      "This bloc does not support actions. Use an AsyncBloc to trigger actions."
+      "This bloc does not support effects. Use an AsyncBloc to trigger effects."
     );
 }

--- a/Bloc.NET/src/BlocBase.cs
+++ b/Bloc.NET/src/BlocBase.cs
@@ -11,8 +11,11 @@ using System;
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-/// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public interface IBloc<TEvent, TState, TAction> : IDisposable {
+/// <typeparam name="TEffect">Type of effects the bloc can trigger.</typeparam>
+public interface IBloc<TEvent, TState, TEffect> : IDisposable
+  where TEvent : notnull
+  where TState : IEquatable<TState>
+  where TEffect : notnull {
   /// <summary>Current state of the bloc.</summary>
   TState State { get; }
 
@@ -26,8 +29,8 @@ public interface IBloc<TEvent, TState, TAction> : IDisposable {
   /// </summary>
   IObservable<TState> States { get; }
 
-  /// <summary>Observable stream of actions triggered by the bloc.</summary>
-  IObservable<TAction> Actions { get; }
+  /// <summary>Observable stream of effects triggered by the bloc.</summary>
+  IObservable<TEffect> Effects { get; }
 
   /// <summary>Observable stream of errors occurring in the bloc.</summary>
   IObservable<Exception> Errors { get; }
@@ -53,9 +56,9 @@ public interface IBloc<TEvent, TState, TAction> : IDisposable {
   event EventHandler<TState> OnState;
 
   /// <summary>
-  /// Event invoked when an action is triggered from the bloc.
+  /// Event invoked when an effect is triggered from the bloc.
   /// </summary>
-  event EventHandler<TAction> OnAction;
+  event EventHandler<TEffect> OnEffect;
 
   /// <summary>
   /// Event invoked when the bloc adds an error.
@@ -87,12 +90,12 @@ public interface IBloc<TEvent, TState, TAction> : IDisposable {
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-/// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public abstract class BlocBase<TEvent, TState, TAction> :
-  IBloc<TEvent, TState, TAction>
+/// <typeparam name="TEffect">Type of effects the bloc can trigger.</typeparam>
+public abstract class BlocBase<TEvent, TState, TEffect> :
+  IBloc<TEvent, TState, TEffect>
   where TEvent : notnull
   where TState : IEquatable<TState>
-  where TAction : notnull {
+  where TEffect : notnull {
   /// <inheritdoc/>
   public abstract TState State { get; }
 
@@ -103,7 +106,7 @@ public abstract class BlocBase<TEvent, TState, TAction> :
   public abstract IObservable<TState> States { get; }
 
   /// <inheritdoc/>
-  public abstract IObservable<TAction> Actions { get; }
+  public abstract IObservable<TEffect> Effects { get; }
 
   /// <inheritdoc/>
   public abstract IObservable<Exception> Errors { get; }
@@ -118,7 +121,7 @@ public abstract class BlocBase<TEvent, TState, TAction> :
   /// <inheritdoc/>
   public abstract event EventHandler<Exception> OnNextError;
   /// <inheritdoc/>
-  public abstract event EventHandler<TAction> OnAction;
+  public abstract event EventHandler<TEffect> OnEffect;
 
   /// <inheritdoc/>
   public abstract void Add(TEvent @event);
@@ -134,12 +137,12 @@ public abstract class BlocBase<TEvent, TState, TAction> :
   protected abstract void OnError(Exception e);
 
   /// <summary>
-  /// Triggers an action. Blocs can call this method while handling events to
-  /// trigger a one-shot action. An action can be any type of object that
-  /// extends <typeparamref name="TAction"/>.
+  /// Triggers an effect. Blocs can call this method while handling events to
+  /// trigger a one-shot side-effect. An effect can be any type of object that
+  /// extends <typeparamref name="TEffect"/>.
   /// </summary>
-  /// <param name="action">Action to trigger.</param>
-  protected abstract void Trigger(TAction action);
+  /// <param name="effect">Effect to trigger.</param>
+  protected abstract void Trigger(TEffect effect);
 
   /// <inheritdoc/>
   public abstract IDisposable Listen(

--- a/Bloc.NET/src/BlocBase.cs
+++ b/Bloc.NET/src/BlocBase.cs
@@ -88,8 +88,11 @@ public interface IBloc<TEvent, TState, TAction> : IDisposable {
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
 /// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public abstract class BlocBase<TEvent, TState, TAction>
-  : IBloc<TEvent, TState, TAction> where TState : IEquatable<TState> {
+public abstract class BlocBase<TEvent, TState, TAction> :
+  IBloc<TEvent, TState, TAction>
+  where TEvent : notnull
+  where TState : IEquatable<TState>
+  where TAction : notnull {
   /// <inheritdoc/>
   public abstract TState State { get; }
 

--- a/Bloc.NET/src/SyncBloc.cs
+++ b/Bloc.NET/src/SyncBloc.cs
@@ -15,8 +15,11 @@ using System.Runtime.CompilerServices;
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
 /// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public abstract class SyncBloc<TEvent, TState, TAction>
-  : GenericBloc<TEvent, TState, TAction> where TState : IEquatable<TState> {
+public abstract class SyncBloc<TEvent, TState, TAction> :
+  GenericBloc<TEvent, TState, TAction>
+  where TEvent : notnull
+  where TState : IEquatable<TState>
+  where TAction : notnull {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>
@@ -24,17 +27,15 @@ public abstract class SyncBloc<TEvent, TState, TAction>
   public SyncBloc(TState initialState) : base(initialState) { }
 
   /// <summary>
-  /// Whenever a bloc processes an event, this method is called with the event
-  /// and expected to return the next state of the bloc. This method is used
-  /// to map an event to a new state based on the bloc's current state.
+  /// Registers an event handler for a specific event type. The event handler
+  /// is a function that receives an event of a specific type and emits one or
+  /// more states in response to the event.
   /// </summary>
-  /// <param name="event">The event to process.</param>
-  public abstract IEnumerable<TState> MapEventToState(TEvent @event);
-
-  /// <inheritdoc/>
-  [MethodImpl(MethodImplOptions.AggressiveInlining)]
-  protected override IObservable<TState> ConvertEvent(TEvent @event) =>
-    MapEventToState(@event).ToObservable();
+  /// <param name="handler">Event handler.</param>
+  /// <typeparam name="TEventType">Type of the event.</typeparam>
+  protected void On<TEventType>(Func<TEventType, IEnumerable<TState>> handler)
+    where TEventType : TEvent =>
+      On<TEventType>((@event) => handler(@event).ToObservable());
 
   /// <inheritdoc/>
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -59,8 +60,10 @@ public abstract class SyncBloc<TEvent, TState, TAction>
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-public abstract class SyncBlocClassic<TEvent, TState>
-  : SyncBloc<TEvent, TState, object> where TState : IEquatable<TState> {
+public abstract class SyncBlocClassic<TEvent, TState> :
+  SyncBloc<TEvent, TState, object>
+  where TEvent : notnull
+  where TState : IEquatable<TState> {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>

--- a/Bloc.NET/src/SyncBloc.cs
+++ b/Bloc.NET/src/SyncBloc.cs
@@ -14,8 +14,9 @@ using System.Runtime.CompilerServices;
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-public abstract class SyncBloc<TEvent, TState> : GenericBloc<TEvent, TState>
-  where TState : IEquatable<TState> {
+/// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
+public abstract class SyncBloc<TEvent, TState, TAction>
+  : GenericBloc<TEvent, TState, TAction> where TState : IEquatable<TState> {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>
@@ -39,4 +40,36 @@ public abstract class SyncBloc<TEvent, TState> : GenericBloc<TEvent, TState>
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
   protected override bool ShouldThrow(Exception e) => true;
   // Sync blocs should always throw exceptions when adding an event.
+}
+
+/// <summary>
+/// <para>
+/// A bloc is a component that processes events and maintains a state. In
+/// game development, blocs can be used in place of traditional state machines,
+/// HSM's, or state charts. While blocs are not as rigorously defined as state
+/// machines, they are easy to test and offer increased flexibility (and often
+/// require less code).
+/// </para>
+/// <para>
+/// Unlike <see cref="SyncBloc{TEvent, TState, TAction}" />, this bloc cannot
+/// trigger actions. The lack of actions replicates the API surface of the
+/// original bloc library for Flutter and is useful when you do not need blocs
+/// to trigger one-shot actions unrelated to state.
+/// </para>
+/// </summary>
+/// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
+/// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
+public abstract class SyncBlocClassic<TEvent, TState>
+  : SyncBloc<TEvent, TState, object> where TState : IEquatable<TState> {
+  /// <summary>
+  /// Creates a new bloc with the given initial state.
+  /// </summary>
+  /// <param name="initialState">Initial state of the bloc.</param>
+  public SyncBlocClassic(TState initialState) : base(initialState) { }
+
+  /// <inheritdoc/>
+  protected override void Trigger(object action) =>
+    throw new InvalidOperationException(
+      "This bloc does not support actions. Use an AsyncBloc to trigger actions."
+    );
 }

--- a/Bloc.NET/src/SyncBloc.cs
+++ b/Bloc.NET/src/SyncBloc.cs
@@ -14,12 +14,12 @@ using System.Runtime.CompilerServices;
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
 /// <typeparam name="TState">Type of state that bloc maintains.</typeparam>
-/// <typeparam name="TAction">Type of actions the bloc can trigger.</typeparam>
-public abstract class SyncBloc<TEvent, TState, TAction> :
-  GenericBloc<TEvent, TState, TAction>
+/// <typeparam name="TEffect">Type of effects the bloc can trigger.</typeparam>
+public abstract class SyncBloc<TEvent, TState, TEffect> :
+  GenericBloc<TEvent, TState, TEffect>
   where TEvent : notnull
   where TState : IEquatable<TState>
-  where TAction : notnull {
+  where TEffect : notnull {
   /// <summary>
   /// Creates a new bloc with the given initial state.
   /// </summary>
@@ -52,10 +52,10 @@ public abstract class SyncBloc<TEvent, TState, TAction> :
 /// require less code).
 /// </para>
 /// <para>
-/// Unlike <see cref="SyncBloc{TEvent, TState, TAction}" />, this bloc cannot
-/// trigger actions. The lack of actions replicates the API surface of the
+/// Unlike <see cref="SyncBloc{TEvent, TState, TEffect}" />, this bloc cannot
+/// trigger effects. The lack of effects replicates the API surface of the
 /// original bloc library for Flutter and is useful when you do not need blocs
-/// to trigger one-shot actions unrelated to state.
+/// to trigger one-shot effects unrelated to state.
 /// </para>
 /// </summary>
 /// <typeparam name="TEvent">Type of events that the bloc receives.</typeparam>
@@ -71,8 +71,8 @@ public abstract class SyncBlocClassic<TEvent, TState> :
   public SyncBlocClassic(TState initialState) : base(initialState) { }
 
   /// <inheritdoc/>
-  protected override void Trigger(object action) =>
+  protected override void Trigger(object effect) =>
     throw new InvalidOperationException(
-      "This bloc does not support actions. Use an AsyncBloc to trigger actions."
+      "This bloc does not support effects. Use a SyncBloc to trigger effects."
     );
 }

--- a/Bloc.NET/src/utilities/BlocGlue.cs
+++ b/Bloc.NET/src/utilities/BlocGlue.cs
@@ -15,9 +15,10 @@ public static class BlocGlueExtensions {
   /// <param name="bloc">The bloc to glue.</param>
   /// <typeparam name="TEvent">Type of the bloc's events.</typeparam>
   /// <typeparam name="TState">Type of the bloc's state.</typeparam>
-  /// <returns>A new <see cref="BlocGlue{TEvent, TState}" /></returns>
-  public static BlocGlue<TEvent, TState> Glue<TEvent, TState>(
-    this IBloc<TEvent, TState> bloc
+  /// <typeparam name="TAction">Type of the bloc's actions.</typeparam>
+  /// <returns>A new <see cref="BlocGlue{TEvent, TState, TAction}" /></returns>
+  public static BlocGlue<TEvent, TState, TAction> Glue<TEvent, TState, TAction>(
+    this IBloc<TEvent, TState, TAction> bloc
   ) where TState : notnull => new(bloc);
 }
 
@@ -29,11 +30,13 @@ public static class BlocGlueExtensions {
 /// </summary>
 /// <typeparam name="TEvent">Type of the bloc's events.</typeparam>
 /// <typeparam name="TState">Type of the bloc's state.</typeparam>
-public class BlocGlue<TEvent, TState> : IDisposable where TState : notnull {
+/// <typeparam name="TAction">Type of the bloc's actions.</typeparam>
+public class BlocGlue<TEvent, TState, TAction>
+  : IDisposable where TState : notnull {
   /// <summary>
   /// Bloc that is glued.
   /// </summary>
-  public IBloc<TEvent, TState> Bloc { get; }
+  public IBloc<TEvent, TState, TAction> Bloc { get; }
 
   private TState _previousState;
 
@@ -41,7 +44,7 @@ public class BlocGlue<TEvent, TState> : IDisposable where TState : notnull {
   private readonly Dictionary<Type, List<Action<TState, dynamic>>> _invokers =
     new();
 
-  internal BlocGlue(IBloc<TEvent, TState> bloc) {
+  internal BlocGlue(IBloc<TEvent, TState, TAction> bloc) {
     Bloc = bloc;
     _previousState = bloc.State;
     Bloc.OnNextState += OnNextState;
@@ -105,7 +108,7 @@ public class BlocGlue<TEvent, TState> : IDisposable where TState : notnull {
   internal interface IBlocStateGlue {
     /// <summary>
     /// Invoke all registered glue actions for a specific type of state. Used
-    /// by <see cref="BlocGlue{TEvent, TState}" />.
+    /// by <see cref="BlocGlue{TEvent, TState, TAction}" />.
     /// </summary>
     /// <param name="state">Current state of the bloc.</param>
     /// <param name="previous">Previous state of the bloc.</param>

--- a/cspell.json
+++ b/cspell.json
@@ -51,6 +51,8 @@
     "reportgenerator",
     "reporttypes",
     "Shouldly",
+    "statechart",
+    "statecharts",
     "subfolders",
     "Substate",
     "targetargs",


### PR DESCRIPTION
- Adds side effect streams — now blocs can trigger one-shot side effects that can be handled using bloc glue.
- Changes event handling API to use `On<TEvent>(_handler)` style registration.

Naturally, these are breaking changes for the API.